### PR TITLE
fix hardcoded servicemonitor label selectors

### DIFF
--- a/charts/atuin/Chart.yaml
+++ b/charts/atuin/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atuin/templates/servicemonitor.yaml
+++ b/charts/atuin/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: atuin
+  name: {{ include "atuin.fullname" . }}
 spec:
   endpoints:
   - interval: 60s
@@ -10,6 +10,5 @@ spec:
     port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/instance: atuin
-      app.kubernetes.io/name: atuin
+      {{- include "atuin.selectorLabels" . | nindent 6 }}
 {{- end}}


### PR DESCRIPTION
`ServiceMonitor` was failing to discover `atuin` endpoint when helm release name wasn't `atuin`.